### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,5 @@ RUN make install
 RUN cp crf_learn crf_test ..
 WORKDIR /ParsCit/crfpp/CRF++-0.51/.libs
 RUN cp -Rf * ../../.libs
+
+WORKDIR /ParsCit/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# ParsCit
+#
+# VERSION 1.0
+FROM 32bit/debian:jessie
+MAINTAINER Min-Yen Kan <knmnyn@hotmail.com>
+
+RUN apt-get update
+RUN apt-get install -y g++ make libexpat1-dev perl ruby
+
+RUN cpan install XML::Twig
+RUN cpan install XML::Writer
+RUN cpan install XML::Writer::String
+
+ADD . /ParsCit
+WORKDIR /ParsCit/crfpp
+RUN tar -xvzf crf++-0.51.tar.gz
+WORKDIR /ParsCit/crfpp/CRF++-0.51
+RUN ./configure
+RUN perl -pi -e 's/#include <cmath>/#include <cmath>\n#include <iostream>/g' node.cpp
+RUN make
+RUN make install
+
+RUN cp crf_learn crf_test ..
+WORKDIR /ParsCit/crfpp/CRF++-0.51/.libs
+RUN cp -Rf * ../../.libs


### PR DESCRIPTION
This pull request adds a Dockerfile to the repository. This should ease the installation process. You can now execute `citeExtract.pl` with just a few commands:
```
$ docker build -t parscit .
$ docker run -v /path/to/pdfs:/pdfs -it parscit bash
/ParsCit/bin# ./citeExtract.pl -m extract_all /pdfs/file_to_process.txt
```
I wasn't able to install the web service in the container (the installation guidelines are less verbose on that subject).