### PR TITLE
Language Option, Split Author Names Option, more UTF8, ...

### DIFF
--- a/bin/prepData.pl
+++ b/bin/prepData.pl
@@ -1,0 +1,58 @@
+#!/usr/bin/perl -CSD
+#
+# Script to transform reference strings to crf++ compatible data.
+# By doing so, CRF++ can be used manually with the trasnformed reference data.
+#
+# Derived from 'parseRefStrings.pl'
+#
+# written by Matthias Bösinger (29.03.2016)
+
+use strict;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use lib "/home/wing.nus/tools/languages/programming/perl-5.10.0/lib/5.10.0";
+use lib "/home/wing.nus/tools/languages/programming/perl-5.10.0/lib/site_perl/5.10.0";
+
+use ParsCit::Controller;
+use CSXUtil::SafeText qw(cleanAll cleanXML);
+
+my $textFile = $ARGV[0];
+my $outFile = $ARGV[1];
+
+if (!defined $textFile || !defined $outFile) {
+    print "Usage: $0 textfile outfile\n";
+    exit;
+}
+
+open (IF, $textFile) || die "Couldn't open text file \"textFile\"!";
+my $normalizedCiteText = "";
+my $line = 0;
+while (<IF>) {
+  chop;
+  # Tr2cfpp needs an enclosing tag for initial class seed.
+  $normalizedCiteText .= "<title> " . $_ . " </title>\n";
+  $line++;
+}
+close (IF);
+
+if ($line == 0) {
+  # Stop - nothing left to do.
+  exit();
+}
+
+our $msg = "";
+my $tmpFile = ParsCit::Tr2crfpp::PrepData(\$normalizedCiteText, $textFile);
+
+open (TF, $tmpFile) || die "Couldn't open tmp file!";
+open (OF, ">$outFile") || die "Couldn't open out file!";
+while (<TF>) {
+	chop;
+	print OF $_ . "\n";
+}
+
+close(TF);
+close(OF);
+
+unlink($tmpFile);
+

--- a/bin/tr2crfpp.pl
+++ b/bin/tr2crfpp.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 # -*- cperl -*-
+#
+# Matthias Bösinger (29.03.2016)
+# -> all changes marked with: MB1
+
 =head1 NAME
 
 tr2crfpp.pl
@@ -22,7 +26,13 @@ tr2crfpp.pl
 require 5.0;
 use Getopt::Std;
 use strict 'vars';
+use utf8;
+use 5.010; 	# MB1
 use FindBin;
+
+binmode STDIN, ":encoding(UTF-8)"; 	# MB1
+binmode STDOUT, ":encoding(UTF-8)"; 	# MB1
+
 # use diagnostics;
 
 ### USER customizable section
@@ -93,21 +103,29 @@ my $filename;
 if ($filename = shift) {
  NEWFILE:
   if (!(-e $filename)) { die "# $progname crash\t\tFile \"$filename\" doesn't exist"; }
-  open (*IF, $filename) || die "# $progname crash\t\tCan't open \"$filename\"";
-  $fh = "IF";
+  open (IF, "<:encoding(UTF-8)", $filename) || die "# $progname crash\t\tCan't open \"$filename\""; 	# set encoding to UTF-8 - MB1
+# open (*IF, $filename) || die "# $progname crash\t\tCan't open \"$filename\"";
+# $fh = "IF";
 } else {
   $filename = "<STDIN>";
   $fh = "STDIN";
 }
 
-while (<$fh>) {
+# while (<$fh>) { 	# set encoding to UTF-8 - MB1
+while (<IF>) { 	# set encoding to UTF-8 - MB1
   if (/^\#/) { next; }			# skip comments
   elsif (/^\s+$/) { next; }		# skip blank lines
   else {
     my $tag = "";
     my @tokens = split(/ +/);
     my @feats = ();
-    my $hasPossibleEditor = (/(ed\.|editor|editors|eds\.)/) ? "possibleEditors" : "noEditors";
+    
+    ###
+    # Regex updated accordingly to changes in Tr2crfpp.pm by Artemy Kolchinsky and new german editor strings in ConfigLang.pm
+    # MB1
+    ###
+    my $hasPossibleEditor = (/[^A-Za-z](ed\.?|editor|editors|eds\.?|Hrsg\.?|Herausgeber|Hg\.?|hgg\.?)/i) ? "possibleEditors" : "noEditors";
+    
     my $j = 0;
     for (my $i = 0; $i <= $#tokens; $i++) {
 #    for (my $i = $#tokens; $i >= 0; $i--) {

--- a/lib/ParsCit/ConfigLang.pm
+++ b/lib/ParsCit/ConfigLang.pm
@@ -1,0 +1,63 @@
+package ParsCit::ConfigLang;
+
+################
+# Written By Matthias Bösinger (29.03.2016)
+# 
+# Modul is used to set language specific data fields.
+# Call of 'Init' with language type passed as parameter, will cause the initialization of the gloabl data fields.
+# hasEditor: Regex used in feature determination to decide if a reference contains editor tokens.
+# authorSplit: Regex used to split contiguous as author tags labeled tokens, into several author-names.
+# authorDelete: Regex used to delete parts of an as author tag labeled token.
+# inMarker: not in use in this version -> could be used for additional feature that marks a collective volume in the reference string
+################
+
+use utf8;
+
+## Global
+$hasEditorRegex = '';
+$authorSplitRegex = '';
+$authorDeleteRegex = '';
+$inMarker = '';
+
+## Language specific data
+my %enData = ( 	'editor' => '[^A-Za-z](ed\.?|editor|editors|eds\.?)',
+				'author' => '^(&|/|and|a\.)$',
+				'delete' => 'et\.? al\.?.*$',
+				'in' 	 => 'in' );
+
+my %deData = ( 	'editor' => '[^A-Za-z](Hrsg\.?|Herausgeber|Hg\.?|hgg\.?)',
+				'author' => '^(&|/|und|u\.)$',
+				'delete' => '(u\.a\..*|et\.? al\.?.*)$',
+				'in' 	 => 'in' );
+
+
+## initialization methods
+sub Init {
+	my ($lang) = @_;
+	
+	if ($lang eq "en") {
+		initData(%enData);
+	}
+	elsif ($lang eq "de") {
+		initData(%deData);
+	}
+	#additional languages might be included here - MB
+	else {
+		return 0;
+	}
+	
+	1;
+}
+
+
+sub initData {
+	my (%data) = @_;
+	
+	$hasEditorRegex = $data{'editor'};
+	$authorSplitRegex = $data{'author'};
+	$authorDeleteRegex = $data{'delete'};
+	$inMarker = $data{'in'};
+	
+}
+
+1;


### PR DESCRIPTION
All changes done for the program 'parseRefStrings.pl'.
Language Option: Language Parameter can be passed to 'parseRefStrings.pl'. New Modul 'ConfigLang' for language data and initialization. Done for German and English.
Split author: If author names stuck together without whitespace (for example: T.W.Adorno), name will be seperated.
Keep Files: Parameter introduced so that Temp Files are kept.
Output-File: Output file bug fixed. Output file is now kept.
UTF-8: Changed encoding at several places to UTF-8.
CRF++ Data: 'prepData.pl' to produce CRF++ compatible Data from reference strings.